### PR TITLE
Options: Crud callbacks: deleteActionCallback, editSubmissionCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The `userFunctions` property in `ptOptions` prop is an object that can contain t
 | `customParse` | function | | A user-defined function to intercept and modify the content of the current page |
 | `customSearch` | function | | A user-defined function to override the search process |
 | `deleteActionCallback` | function | | A user-defined function that is passed the rows were just deleted |
+| `editSubmissionCallback` | function | | A user-defined function that is called after submitting an edit, and is passed the new row data |
 
 ❗ When retrieving data in a user-defined function, pay attention to the [special instructs](#special-instructs)!
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The `userFunctions` property in `ptOptions` prop is an object that can contain t
 | `dataFeed` | function | async () => ({}) | When `isDataRemote` is `true`, the output of this function will be used as `ptData` prop |
 | `customParse` | function | | A user-defined function to intercept and modify the content of the current page |
 | `customSearch` | function | | A user-defined function to override the search process |
+| `deleteActionCallback` | function | | A user-defined function that is passed the rows were just deleted |
 
 ❗ When retrieving data in a user-defined function, pay attention to the [special instructs](#special-instructs)!
 

--- a/app/src/lib/components/PowerTable.svelte
+++ b/app/src/lib/components/PowerTable.svelte
@@ -67,6 +67,7 @@ export interface Options {
         customParse?(data: Data[]): Data[],
         customSearch?(data: Data[], searchPhrase: string): {data: Data[], continue: boolean},
         deleteActionCallback?(rows: Data[]): void,
+        editSubmissionCallback?(row: Data): void,
     },
     segments?: Record<string,Array<'settings'|'search'|'pagination'|'table'|'dropdown'|'stats'>>,
     sortOrder?: {[k in SortString]?: SortString},
@@ -721,14 +722,19 @@ function rowClicked(e: Event, index: number) {
     dispatch('rowClicked', {event: e, data: pageData[index]});
 
     if ((<HTMLInputElement>e.target).dataset?.name === 'edit-submit') {
+        let row = data[pageData[index][dataIdKey]];
         let textareaEls = (<HTMLInputElement>e.target).closest('tr')?.querySelectorAll('textarea[data-name=edit-textarea]');
         textareaEls!.forEach(textareaEl => {
-            data[pageData[index][dataIdKey]][(<HTMLInputElement>textareaEl)?.dataset?.key ?? ''] = (<HTMLInputElement>textareaEl)?.value ?? '';
+            row[(<HTMLInputElement>textareaEl)?.dataset?.key ?? ''] = (<HTMLInputElement>textareaEl)?.value ?? '';
         });
 
-        data[pageData[index][dataIdKey]][checkboxKey] = false;
-
+        row[checkboxKey] = false;
         initialize(instructs, options, data);
+
+        const userCallback = options?.userFunctions?.editSubmissionCallback;
+        if (userCallback) {
+            userCallback(row);
+        }
     }
 }
 

--- a/app/src/lib/components/PowerTable.svelte
+++ b/app/src/lib/components/PowerTable.svelte
@@ -847,17 +847,14 @@ export function addAction(e: Event) {
 export function deleteAction(e: Event) {
     closeMenu(e);
     
-    let deletedRows = [];
-    let remainingRows = [];
-    for (const row of data) {
+    let deletedRows: Data[] = [];
+    data = data.filter(row => {
         if (row[checkboxKey]) {
             deletedRows.push(row);
-        } else { 
-            remainingRows.push(row);
         }
-    }
+        return !row[checkboxKey];
+    });
 
-    data = remainingRows;
     initialize(instructs, options, data);
 
     const userCallback = options?.userFunctions?.deleteActionCallback;

--- a/app/src/lib/components/PowerTable.svelte
+++ b/app/src/lib/components/PowerTable.svelte
@@ -66,6 +66,7 @@ export interface Options {
         dataFeed?(data: Record<string,any>): Promise<DataFeed>,
         customParse?(data: Data[]): Data[],
         customSearch?(data: Data[], searchPhrase: string): {data: Data[], continue: boolean},
+        deleteActionCallback?(rows: Data[]): void,
     },
     segments?: Record<string,Array<'settings'|'search'|'pagination'|'table'|'dropdown'|'stats'>>,
     sortOrder?: {[k in SortString]?: SortString},
@@ -839,12 +840,24 @@ export function addAction(e: Event) {
 
 export function deleteAction(e: Event) {
     closeMenu(e);
+    
+    let deletedRows = [];
+    let remainingRows = [];
+    for (const row of data) {
+        if (row[checkboxKey]) {
+            deletedRows.push(row);
+        } else { 
+            remainingRows.push(row);
+        }
+    }
 
-    data = data.filter(row => {
-        return !row[checkboxKey];
-    });
-
+    data = remainingRows;
     initialize(instructs, options, data);
+
+    const userCallback = options?.userFunctions?.deleteActionCallback;
+    if (userCallback) {
+        userCallback(deletedRows);
+    }
 }
 
 export function getData(removeMetadata = true, include = ['options','instructs','data','search','filters']) {

--- a/app/src/routes/examples/example7/+page.svelte
+++ b/app/src/routes/examples/example7/+page.svelte
@@ -29,6 +29,7 @@ let ptOptions: Options = {
     },
     userFunctions: {
         deleteActionCallback: (rows) => console.log('deleted rows:', rows),
+        editSubmissionCallback: (row) => console.log('updated row:', row),
     },
 }
 

--- a/app/src/routes/examples/example7/+page.svelte
+++ b/app/src/routes/examples/example7/+page.svelte
@@ -26,7 +26,10 @@ let ptOptions: Options = {
         'topBar': ['settings', 'search', 'pagination'],
         'pTable': ['table'],
         'bottomBar': ['dropdown', 'stats', 'pagination'],
-    }
+    },
+    userFunctions: {
+        deleteActionCallback: (rows) => console.log('deleted rows:', rows),
+    },
 }
 
 function importJsonData(e: Event) {


### PR DESCRIPTION
**Problem**: Currently there is no way to update a remote database based on small edits in the PowerTable.
This change adds two callbacks to allow use of PowerTable for CRUD apps.

## Changes
- `ptOptions.userFunctions` now has `deleteActionCallback` and `editSubmissionCallback`
- Example7 updated to show console output for the callbacks

---

Note: Apologies for any of my naivety here, and in any follow up discussion. This is my first time working on reactive front ends (and first time using javascript in a while; first time using typescript).